### PR TITLE
fix: Do not require drupal/core, that leads to fail when bumping major versions.

### DIFF
--- a/.github/workflows/drupal-coding-standards.yml
+++ b/.github/workflows/drupal-coding-standards.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3']
+        php-versions: ['8.3', '8.4']
 
     steps:
       - name: Checkout

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,8 +17,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        drupal-core: ['10.3.x']
-        php-versions: ['8.3']
+        drupal-core: ['10.4.x', '11.1.x']
+        php-versions: ['8.3', '8.4']
+        exclude:
+          - drupal-core: '10.4.x'
+            php-versions: '8.4'
+
     steps:
       - name: Checkout Drupal core
         uses: actions/checkout@v4
@@ -61,7 +65,7 @@ jobs:
           echo "DRUPAL_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
 
       - name: Install drush
-        run: composer require "drush/drush ^12.0"
+        run: composer require "drush/drush"
 
       - name: Start MySql service
         run: |

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=8.3",
-        "drupal/core": "^10",
         "drupal/honeypot": "^2",
         "drupal/openid_connect": "^3.0",
         "drupal/openid_connect_windows_aad": "^2.0@beta"


### PR DESCRIPTION
The module info yaml has core_requirements, which is enough.