### PR TITLE
[OPS-11508] Load the user entity for the current user

### DIFF
--- a/ocha_entraid.module
+++ b/ocha_entraid.module
@@ -5,6 +5,8 @@
  * The ocha_entraid module file.
  */
 
+use Drupal\user\Entity\User;
+
 /**
  * Implements hook_preprocess_status_messages().
  *
@@ -19,8 +21,8 @@ function ocha_entraid_preprocess_status_messages(&$variables) {
   }
 
   // Only filter the error if the account is blocked.
-  $account = \Drupal::currentUser();
-  if (!$account->isBlocked()) {
+  $account = User::load(\Drupal::currentUser()->id());
+  if (!$account || !$account->isBlocked()) {
     return;
   }
 


### PR DESCRIPTION
Refs: OPS-11508

`currentUser()` returns an `AccountProxy` that doesn't have a `isBlocked` method.

See: https://github.com/UN-OCHA/rwint9-site/actions/runs/15153744317/job/42604495116?pr=1117